### PR TITLE
Troca do termo "Cadeia de caracteres" por String

### DIFF
--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Cadeias de caracteres de Conexão - Core EF"
+title: "Strings de Conexão - Core EF"
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016
@@ -12,13 +12,13 @@ ms.translationtype: MT
 ms.contentlocale: pt-BR
 ms.lasthandoff: 10/27/2017
 ---
-# <a name="connection-strings"></a>Cadeias de caracteres de conexão
+# <a name="connection-strings"></a>Strings de conexão
 
-A maioria dos provedores de banco de dados requer alguma forma de cadeia de caracteres de conexão para se conectar ao banco de dados. Às vezes, essa cadeia de caracteres de conexão contém informações confidenciais que precisam ser protegidos. Talvez você precise alterar a cadeia de caracteres de conexão ao mover seu aplicativo entre ambientes, como desenvolvimento, teste e produção.
+A maioria dos provedores de banco de dados requer alguma forma de string de conexão para se conectar ao banco de dados. Às vezes, essa string de conexão contém informações confidenciais que precisam ser protegidos. Talvez você precise alterar a string de conexão ao mover seu aplicativo entre ambientes, como desenvolvimento, teste e produção.
 
 ## <a name="net-framework-applications"></a>Aplicativos do .NET framework
 
-Aplicativos do .NET framework, como WinForms, o WPF, o Console e o ASP.NET 4, com um padrão de cadeia de caracteres de conexão testada e. A cadeia de caracteres de conexão deve ser adicionada ao seu arquivo App. config de aplicativos (Web. config se você estiver usando o ASP.NET). Se a cadeia de conexão contém informações confidenciais, como nome de usuário e senha, você pode proteger o conteúdo do arquivo de configuração usando [configuração protegida](https://docs.microsoft.com/dotnet/framework/data/adonet/connection-strings-and-configuration-files#encrypting-configuration-file-sections-using-protected-configuration).
+Aplicativos do .NET framework, como WinForms, o WPF, o Console e o ASP.NET 4, com um padrão de string de conexão testada e. A string de conexão deve ser adicionada ao seu arquivo App. config de aplicativos (Web. config se você estiver usando o ASP.NET). Se a string contém informações confidenciais, como nome de usuário e senha, você pode proteger o conteúdo do arquivo de configuração usando [configuração protegida](https://docs.microsoft.com/dotnet/framework/data/adonet/connection-strings-and-configuration-files#encrypting-configuration-file-sections-using-protected-configuration).
 
 ``` xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -51,7 +51,7 @@ public class BloggingContext : DbContext
 
 ## <a name="universal-windows-platform-uwp"></a>UWP (Plataforma Universal do Windows)
 
-Cadeias de caracteres de Conexão em um aplicativo de UWP costumam ser uma conexão SQLite que especifica apenas um nome de arquivo local. Normalmente, eles não contêm informações confidenciais e não precisam ser alteradas como um aplicativo é implantado. Assim, essas cadeias de caracteres de conexão são normalmente não há problemas em código, conforme mostrado abaixo. Se você deseja movê-los fora do código, em seguida, UWP oferece suporte ao conceito de configurações, consulte o [seção configurações do aplicativo da documentação UWP](https://docs.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data) para obter detalhes.
+Strings de Conexão em um aplicativo de UWP costumam ser uma conexão SQLite que especifica apenas um nome de arquivo local. Normalmente, eles não contêm informações confidenciais e não precisam ser alteradas como um aplicativo é implantado. Assim, essas cadeias de caracteres de conexão são normalmente não há problemas em código, conforme mostrado abaixo. Se você deseja movê-los fora do código, em seguida, UWP oferece suporte ao conceito de configurações, consulte o [seção configurações do aplicativo da documentação UWP](https://docs.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data) para obter detalhes.
 
 ``` csharp
 public class BloggingContext : DbContext
@@ -68,7 +68,7 @@ public class BloggingContext : DbContext
 
 ## <a name="aspnet-core"></a>ASP.NET Core
 
-No núcleo do ASP.NET, o sistema de configuração é muito flexível e a cadeia de caracteres de conexão pode ser armazenada em `appsettings.json`, uma variável de ambiente, o armazenamento de segredo do usuário ou outra fonte de configuração. Consulte o [seção de configuração da documentação do ASP.NET Core](https://docs.asp.net/en/latest/fundamentals/configuration.html) para obter mais detalhes. O exemplo a seguir mostra a cadeia de conexão armazenada na `appsettings.json`.
+No núcleo do ASP.NET, o sistema de configuração é muito flexível e a string de conexão pode ser armazenada em `appsettings.json`, uma variável de ambiente, o armazenamento de segredo do usuário ou outra fonte de configuração. Consulte o [seção de configuração da documentação do ASP.NET Core](https://docs.asp.net/en/latest/fundamentals/configuration.html) para obter mais detalhes. O exemplo a seguir mostra a cadeia de conexão armazenada na `appsettings.json`.
 
 ``` json
 {
@@ -78,7 +78,7 @@ No núcleo do ASP.NET, o sistema de configuração é muito flexível e a cadeia
 }
 ```
 
-O contexto é normalmente configurado no `Startup.cs` com a cadeia de caracteres de conexão que está sendo lida da configuração. Observe o `GetConnectionString()` método procura um valor de configuração cuja chave `ConnectionStrings:<connection string name>`.
+O contexto é normalmente configurado no `Startup.cs` com a string de conexão que está sendo lida da configuração. Observe o `GetConnectionString()` método procura um valor de configuração cuja chave `ConnectionStrings:<connection string name>`.
 
 ``` csharp
 public void ConfigureServices(IServiceCollection services)

--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Strings de Conexão - Core EF"
+"Cadeias de conexão - Core EF"
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016
@@ -12,13 +12,13 @@ ms.translationtype: MT
 ms.contentlocale: pt-BR
 ms.lasthandoff: 10/27/2017
 ---
-# <a name="connection-strings"></a>Strings de conexão
+# <a name="connection-strings"></a>Cadeias de conexão
 
-A maioria dos provedores de banco de dados requer alguma forma de string de conexão para se conectar ao banco de dados. Às vezes, essa string de conexão contém informações confidenciais que precisam ser protegidos. Talvez você precise alterar a string de conexão ao mover seu aplicativo entre ambientes, como desenvolvimento, teste e produção.
+A maioria dos provedores de banco de dados requer alguma forma de cadeia de conexão para se conectar ao banco de dados. Às vezes, essa cadeia de conexão contém informações confidenciais que precisam ser protegidas. Talvez você precise alterar a cadeia de conexão ao mover seu aplicativo entre ambientes, como desenvolvimento, teste e produção.
 
 ## <a name="net-framework-applications"></a>Aplicativos do .NET framework
 
-Aplicativos do .NET framework, como WinForms, o WPF, o Console e o ASP.NET 4, com um padrão de string de conexão testada e. A string de conexão deve ser adicionada ao seu arquivo App. config de aplicativos (Web. config se você estiver usando o ASP.NET). Se a string contém informações confidenciais, como nome de usuário e senha, você pode proteger o conteúdo do arquivo de configuração usando [configuração protegida](https://docs.microsoft.com/dotnet/framework/data/adonet/connection-strings-and-configuration-files#encrypting-configuration-file-sections-using-protected-configuration).
+Aplicativos do .NET framework, como WinForms, o WPF, o Console e o ASP.NET 4, com um padrão de cadeia de conexão testada e. A cadeia de conexão deve ser adicionada ao seu arquivo App. config de aplicativos (Web. config se você estiver usando o ASP.NET). Se a cadeia contém informações confidenciais, como nome de usuário e senha, você pode proteger o conteúdo do arquivo de configuração usando [configuração protegida](https://docs.microsoft.com/dotnet/framework/data/adonet/connection-strings-and-configuration-files#encrypting-configuration-file-sections-using-protected-configuration).
 
 ``` xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -51,7 +51,7 @@ public class BloggingContext : DbContext
 
 ## <a name="universal-windows-platform-uwp"></a>UWP (Plataforma Universal do Windows)
 
-Strings de Conexão em um aplicativo de UWP costumam ser uma conexão SQLite que especifica apenas um nome de arquivo local. Normalmente, eles não contêm informações confidenciais e não precisam ser alteradas como um aplicativo é implantado. Assim, essas cadeias de caracteres de conexão são normalmente não há problemas em código, conforme mostrado abaixo. Se você deseja movê-los fora do código, em seguida, UWP oferece suporte ao conceito de configurações, consulte o [seção configurações do aplicativo da documentação UWP](https://docs.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data) para obter detalhes.
+Cadeias de Conexão em um aplicativo UWP são, normalmente, conexões do SQLite que especificam apenas o nome de arquivo local. Normalmente, elas não contêm informações confidenciais e não precisam ser alteradas quando um aplicativo é implantado. Assim, essas cadeias de conexão podem permanecer no código na maioria das vezes, conforme mostrado abaixo. Se deseja retirá-las do código, o UWP oferece suporte ao conceito de configurações, consulte o [seção configurações do aplicativo da documentação UWP](https://docs.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data) para obter detalhes.
 
 ``` csharp
 public class BloggingContext : DbContext
@@ -68,7 +68,7 @@ public class BloggingContext : DbContext
 
 ## <a name="aspnet-core"></a>ASP.NET Core
 
-No núcleo do ASP.NET, o sistema de configuração é muito flexível e a string de conexão pode ser armazenada em `appsettings.json`, uma variável de ambiente, o armazenamento de segredo do usuário ou outra fonte de configuração. Consulte o [seção de configuração da documentação do ASP.NET Core](https://docs.asp.net/en/latest/fundamentals/configuration.html) para obter mais detalhes. O exemplo a seguir mostra a cadeia de conexão armazenada na `appsettings.json`.
+No núcleo do ASP.NET, o sistema de configuração é muito flexível e a cadeia de conexão pode ser armazenada no 'appsettings.json', em uma variável de ambiente, no armazenamento de segredo do usuário ou em outra fonte de configuração. Consulte a [seção de configuração da documentação do ASP.NET Core](https://docs.asp.net/en/latest/fundamentals/configuration.html) para obter mais detalhes. O exemplo a seguir mostra a cadeia de conexão armazenada no `appsettings.json`.
 
 ``` json
 {
@@ -78,8 +78,7 @@ No núcleo do ASP.NET, o sistema de configuração é muito flexível e a string
 }
 ```
 
-O contexto é normalmente configurado no `Startup.cs` com a string de conexão que está sendo lida da configuração. Observe o `GetConnectionString()` método procura um valor de configuração cuja chave `ConnectionStrings:<connection string name>`.
-
+O contexto é normalmente configurado em `Startup.cs` com a cadeia de conexão que está sendo lida da configuração. Observe que o método `GetConnectionString()` procura por um valor de configuração cuja chave seja `ConnectionStrings:<connection string name>`.
 ``` csharp
 public void ConfigureServices(IServiceCollection services)
 {


### PR DESCRIPTION
Em Português Brasileiro não traduzimos o termo String.