### PR TITLE
Fix plural agreement and gender agreement.

### DIFF
--- a/entity-framework/core/saving/async.md
+++ b/entity-framework/core/saving/async.md
@@ -13,7 +13,7 @@ ms.locfileid: "42997276"
 ---
 # <a name="asynchronous-saving"></a>Salvamento assíncrono
 
-O salvamento assíncrono evita o bloqueio de um thread enquanto as alterações são gravadas no banco de dados. Isso pode ser útil para evitar o congelamento da interface do usuário de um aplicativo de cliente espesso. As operações assíncronas também pode aumentar a taxa de transferência em um aplicativo Web, em que o thread pode ser liberado para atender a outras solicitações enquanto a operação do banco de dados é concluída. Para saber mais, veja [Programação assíncrona em C#](https://docs.microsoft.com/dotnet/csharp/async).
+O salvamento assíncrono evita o bloqueio de uma thread enquanto as alterações são gravadas no banco de dados. Isso pode ser útil para evitar o congelamento da interface do usuário de um aplicativo de cliente espesso. As operações assíncronas também podem aumentar a taxa de transferência em um aplicativo Web, em que a thread pode ser liberada para atender a outras solicitações enquanto a operação do banco de dados é concluída. Para saber mais, veja [Programação assíncrona em C#](https://docs.microsoft.com/dotnet/csharp/async).
 
 > [!WARNING]  
 > O EF Core não oferece suporte para várias operações simultâneas sendo executadas na mesma instância de contexto. Aguarde sempre a conclusão de uma operação antes de iniciar a operação seguinte. Isso geralmente é feito usando a palavra-chave `await` em cada operação assíncrona.


### PR DESCRIPTION
The word "thread" is referred as a feminine word in portuguese, so the words "um","o" and "liberado" is changed accordingly.
In the phrase "As operações assíncronas também pode aumentar a taxa de transferência em um aplicativo Web,...", the word "pode" refers to the plural expression "as operações assíncronas". So it is changed to "podem".